### PR TITLE
Rename /products to /collections, be less demanding, align with STAC …

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ and **Orders**. The process of interacting with a data provider is done through 
 
 - **Conformance URI:** <https://stat-api.example.com/v0.1.0/core>
 
-The core of STAT API includes the `/products` endpoint and the `/orders` endpoint.
+The core of STAT API includes the `/collections` endpoint and the `/orders` endpoint.
 
-To know which constraints are available for which *product_id*, users first explore [/products](./product).
+To know which constraints are available for which *product_id*, users first explore [/collections](./product).
 These constraints can be used to form a POST to the [/orders](./order) endpoint.
 
 ### Opportunities
 
 The `/opportunities` endpoint provides additional functionality on top of core and is designed to be used
-after `/products` and before `/orders`. It allows users more fine-grained 
+after `/collections` and before `/orders`. It allows users more fine-grained 
 control and selection of available tasking opportunities by letting them explore the opportunities which 
 are available for a chosen order configuration. The opportunities are 
 represented in a FeatureCollection, with order specific attributes and values in the feature properties.
@@ -48,8 +48,8 @@ column is more of an example in some cases.
 | Endpoint                    | Specified in  | Accepts                                                      | Returns                                                      | Description                                                  |
 | --------------------------- | ------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | `GET /`                     | Core          | -                                                            | [Landing Page](#landing-page)                                |                                                              |
-| `GET /products`             | Core          | -                                                            | [Products Collection](./product/README.md)                   | Figure out which constraints are available for which `product_id` |
-| `GET /products/{productId}` | Core          | -                                                            | [Product](./product/README.md)                               |                                                              |
+| `GET /collections`             | Core          | -                                                            | [Products Collection](./product/README.md)                   | Figure out which constraints are available for which `product_id` |
+| `GET /collections/{productId}` | Core          | -                                                            | [Product](./product/README.md)                               |                                                              |
 | `GET /orders`               | Core          | -                                                            | [Orders Collection](./order/README.md#order-collection)      |                                                              |
 | `POST /orders`              | Core          | [Order Request](./order/README.md#order-request)             | [Order Object](./order/README.md#order-pobject)              | Order a capture with a particular set of constraints         |
 | `POST /opportunities`       | Opportunities | [Opportunity Request](./opportunity/README.md#opportunity-request) | [Opportunities Collection](./opportunity/README.md#opportunities-collection) | Explore the opportunities available for a particular set of constraints |

--- a/product/README.md
+++ b/product/README.md
@@ -8,16 +8,16 @@ STAT Product objects are represented in JSON format and are very flexible. Any J
 
 | Element         | Type                                             | Description                                                  |
 | --------------- | ------------------------------------------------ | ------------------------------------------------------------ |
-| type            | string                                           | **REQUIRED.** Must be set to `Product` to be a valid Product. |
+| type            | string                                           | **REQUIRED.** Must be set to `Collection` to be a valid Product. |
 | id              | string                                           | **REQUIRED.** Identifier for the Product that is unique across the provider. |
 | conformsTo      | \[string\]                                       | Conformance classes that apply to the product specifically. |
 | title           | string                                           | A short descriptive one-line title for the Product.       |
 | description     | string                                           | **REQUIRED.** Detailed multi-line description to fully explain the Collection. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |
 | keywords        | \[string]                                        | List of keywords describing the Product.                  |
-| license         | string                                           | **REQUIRED.** Collection's license(s), either a SPDX [License identifier](https://spdx.org/licenses/), `various` if multiple licenses apply or `proprietary` for all other cases. |
+| license         | string                                           | Collection's license(s), either a SPDX [License identifier](https://spdx.org/licenses/), `other` for all other cases. |
 | providers       | \[[Provider Object](#provider-object)]           | A list of providers, which may include all organizations capturing or processing the data or the hosting provider. Providers should be listed in chronological order with the most recent provider being the last element of the list. |                |
 | links           | \[[Link Object](#link-object)]                   | **REQUIRED.** A list of references to other documents.       |
-| parameters | JSON Schema | JSON Schema that defines the Opportunity and Order properties that can be used in cql2json filter statements. |
+| parameters      | JSON Schema                                      | JSON Schema that defines the Opportunity and Order properties that can be used in cql2json filter statements. |
 
 
 ### Provider Object
@@ -31,7 +31,7 @@ May also include information about the final storage provider hosting the data.
 | ----------- | --------- | ------------------------------------------------------------ |
 | name        | string    | **REQUIRED.** The name of the organization or the individual. |
 | description | string    | Multi-line description to add further provider information such as processing details for processors and producers, hosting details for hosts or basic contact information. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |
-| roles       | \[string] | Role of the provider. Set to `producer` or `reseller`|
+| roles       | \[string] | Role of the provider. Set to `producer` or `reseller`. |
 | url         | string    | Homepage on which the provider describes the dataset and publishes contact information. |
 
 **roles**: The provider's role(s) can be one or more of the following elements:

--- a/stat.yaml
+++ b/stat.yaml
@@ -87,7 +87,7 @@ paths:
           $ref: "#/components/responses/Error"
         "5XX":
           $ref: "#/components/responses/Error"
-  "/products":
+  "/collections":
     get:
       tags:
         - Products
@@ -116,7 +116,7 @@ paths:
           $ref: "#/components/responses/Error"
         "5XX":
           $ref: "#/components/responses/Error"
-  "/products/{productId}":
+  "/collections/{productId}":
     get:
       tags:
         - Products


### PR DESCRIPTION
- Rename /products to /collections so that people can merge with STAC if they want #91
- be less demanding, don't require license
- align with STAC 1.1

This allows you to use STAC API if you want, but you don't need to.