### PR TITLE
remove unnecessary reference in /orders description to Order link rel

### DIFF
--- a/order/README.md
+++ b/order/README.md
@@ -55,8 +55,6 @@ Location: https://example.com/orders/123
 | orders     | \[[Order Object](#order-object)\]          | **REQUIRED.** A list of orders. |
 | links      | Map\<object, Link Object> | **REQUIRED.** Links for e.g. pagination. |
 
-If the `GET /orders/{orderId}/status` endpoint is implemented, there must be a link to the endpoint using the relation type `status`.
-
 ## GET /orders/\{id\}
 
 ### Get Order Response


### PR DESCRIPTION
- https://github.com/stapi-spec/stapi-spec/issues/197

The reference in question was removed, as it was in the section discussion the /orders response (which should not have links to specific order statuses), whereas the description of order status in the Order object section was already correct wrt `monitor` being the relation name.