### PR TITLE
rename constraints to queryables and allow only filter field in search/create body (remove datetime and geometry)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+### Added
+
+none
+
+### Changed
+
+- Create-order endpoint now pluralized to `/product/{productId}/orders`
+- Order Statuses retrieval endpoint now plural (`/statuses`)
+- Product Parameters renamed to Constraints
+- Product Constraints renamed (again) to Queryables to align with OGC Features API terminology
+- Opportunities search and Order creation parameters `datetime` and `geometry` removed in favor of using existing
+  support in CQL2 for datetime comparison and spatial intersects operations.
+  
+
+### Deprecated
+
+none
+
+### Removed
+
+none
+
+### Fixed
+
+none
+
+### Security
+
+none

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
   - [Table of Contents](#table-of-contents)
   - [About](#about)
   - [Introduction](#introduction)
+  - [Other Documents](#other-documents)
   - [STAPI Description](#stapi-description)
     - [Core](#core)
       - [Landing Page](#landing-page)
@@ -36,6 +37,11 @@ The STAPI is primarily designed around machine-to-machine interactions.
 
 See the [Product README](product/README.md) for more.
 
+## Other Documents
+
+- [CHANGELOG](changelog.md)
+- [ADRs](adrs.md)
+
 ## STAPI Description
 
 ### Core
@@ -65,12 +71,18 @@ Fields that can be included in the response body for `GET /`.
 
 ##### Relation Types
 
+STAPI follows the principles of Hypermedia as the Engine of Application State (HATEOAS) by using link relations
+to provide hypermedia navigation through the API. While STAPI also defines specific API endpoints that must be
+implemented, these should also be discoverable by clients through various link relations. The only API endpoint
+that a client should need to know of is the root endpoint, and the URLs for all other endpoints should come from
+looking at link relations.
+
 | Endpoint                                     | Relation Type      |
 | -------------------------------------------- | ------------------ |
 | `GET /conformance`                           | `conformance`      |
 | `GET /products`                              | `products`         |
 | `GET /products/{productId}`                  | `product`          |
-| `GET /products/{productId}/constraints`      | `constraints`      |
+| `GET /products/{productId}/queryables`       | `queryables`       |
 | `GET /products/{productId}/order-parameters` | `order-parameters` |
 | `POST /products/{productId}/orders`          | `create-order`     |
 | `GET /products/{productId}/orders`           | `orders`           |
@@ -104,9 +116,9 @@ column is more of an example in some cases.
 | -------------------------------------------- | ------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `GET /`                                      | Core          | -                                                                  | [Landing Page](#landing-page)                                                |                                                                                                                                                                                                                                     |
 | `GET /conformance`                           | Core          | -                                                                  | Conformance Classes                                                          |                                                                                                                                                                                                                                     |
-| `GET /products`                              | Core          | -                                                                  | [Products Collection](./product/README.md)                                   | Figure out which constraints are available for which `productId`                                                                                                                                                                    |
+| `GET /products`                              | Core          | -                                                                  | [Products Collection](./product/README.md)                                   | `productId`                                                                                                                                                                                                                         |
 | `GET /products/{productId}`                  | Core          | -                                                                  | [Product](./product/README.md)                                               |                                                                                                                                                                                                                                     |
-| `GET /products/{productId}/constraints`      | Core          | -                                                                  | JSON Schema                                                                  |                                                                                                                                                                                                                                     |
+| `GET /products/{productId}/queryables`       | Core          | -                                                                  | JSON Schema                                                                  |                                                                                                                                                                                                                                     |
 | `GET /products/{productId}/order-parameters` | Core          | -                                                                  | JSON Schema                                                                  |                                                                                                                                                                                                                                     |
 | `GET /orders`                                | Core          | -                                                                  | [Orders Collection](./order/README.md#order-collection)                      |                                                                                                                                                                                                                                     |
 | `GET /orders/{orderId}`                      | Core          | -                                                                  | [Order Object](./order/README.md#order-pobject)                              |                                                                                                                                                                                                                                     |
@@ -124,18 +136,27 @@ requires they also live at the `/conformance` endpoint. STAPI's conformance stru
 
 ### Conformance Class Table
 
-| **Name**              | **Specified in**                       | **Conformance URI**                             | **Description**                                                                          |
-| --------------------- | -------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| STAPI - Core          | Core                                   | https://stapi.example.com/v0.1.0/core           | Specifies the STAPI Landing page `/`, communicating conformance and available endpoints. |
-| STAPI - Opportunities | [Opportunities](opportunity/README.md) | https://stapi.example.com/v0.1.0/opportunities  | Enables request of potential tasking opportunities                                       |
-| STAPI - Core          | Core                                   | https://geojson.org/schema/Point.json           | Allows submitting orders with GeoJSON points                                             |
-| STAPI - Core          | Core                                   | https://geojson.org/schema/Linestring.json      | Allows submitting orders with GeoJSON linestrings                                        |
-| STAPI - Core          | Core                                   | https://geojson.org/schema/Polygon.json         | Allows submitting orders with GeoJSON polygons                                           |
-| STAPI - Core          | Core                                   | https://geojson.org/schema/MultiPoint.json      | Allows submitting orders with GeoJSON multi points                                       |
-| STAPI - Core          | Core                                   | https://geojson.org/schema/MultiPolygon.json    | Allows submitting orders with GeoJSON multi polygons                                     |
-| STAPI - Core          | Core                                   | https://geojson.org/schema/MultiLineString.json | Allows submitting orders with GeoJSON multi linestring                                   |
+| **Name**                           | **Specified in**                       | **Conformance URI**                                                     | **Description**                                                                          |
+| ---------------------------------- | -------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| STAPI - Core                       | Core                                   | https://stapi.example.com/v0.1.0/core                                   | Specifies the STAPI Landing page `/`, communicating conformance and available endpoints. |
+| STAPI - Opportunities              | [Opportunities](opportunity/README.md) | https://stapi.example.com/v0.1.0/opportunities                          | Enables request of potential tasking opportunities                                       |
+| CQL2 JSON                          | CQL2                                   | http://www.opengis.net/spec/cql2/1.0/conf/cql2-json                     | Allows using CQL2 formatted as JSON                                                                   |
+| Basic-CQL2                         | CQL2                                   | http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2                    | Allows using logical operators (AND, OR, NOT) and comparison operators (=, <>, <, <=, >, >=), and IS NULL with string, numeric, boolean, date, and datetime types.                   |
+| CQL2 Basic Spatial Functions       | CQL2                                   | http://www.opengis.net/spec/cql2/1.0/conf/basic-spatial-functions          | Allows using spatial intersects (`s_intersects`) operator                                |
+| CQL2 Advanced Comparison Operators | CQL2                                   | http://www.opengis.net/spec/cql2/1.0/conf/advanced-comparison-operators | Allows using operators `LIKE`, `BETWEEN` and `IN`                                        |
+| GeoJSON Point                      | GeoJSON                                | https://geojson.org/schema/Point.json                                   | Allows submitting orders with GeoJSON points                                             |
+| GeoJSON LineString                 | GeoJSON                                | https://geojson.org/schema/LineString.json                              | Allows submitting orders with GeoJSON linestrings                                        |
+| GeoJSON Polygon                    | GeoJSON                                | https://geojson.org/schema/Polygon.json                                 | Allows submitting orders with GeoJSON polygons                                           |
+| GeoJSON MultiPoint                 | GeoJSON                                | https://geojson.org/schema/MultiPoint.json                              | Allows submitting orders with GeoJSON multi points                                       |
+| GeoJSON MultiPolygon               | GeoJSON                                | https://geojson.org/schema/MultiPolygon.json                            | Allows submitting orders with GeoJSON multi polygons                                     |
+| GeoJSON MultiLineString            | GeoJSON                                | https://geojson.org/schema/MultiLineString.json                         | Allows submitting orders with GeoJSON multilinestring                                    |
 
-See [the STAPI Demo](https://github.com/Element84/stat-api-demo)
+It is required to support the CQL2 JSON, Basic CQL2, and CQL2 Basic Spatial Operators classes.
+Other [CQL2 Conformance classes](https://docs.ogc.org/is/21-065r2/21-065r2.html) may be supported at the
+discretion of the implementer. 
+
+See [the STAPI Demo](https://github.com/Element84/stat-api-demo) for an example of advertising these
+conformance classes.
 
 ## Pagination
 

--- a/adrs.md
+++ b/adrs.md
@@ -1,0 +1,40 @@
+# Architectural Decision Records
+
+The purpose of this document is record design decisions for this specification.
+
+These decisions should follow the following list format:
+
+- Context: `<use case/user story>`
+- Concern: `<concern>`
+- Decision: `<option>`
+- Neglected: `<other options>`
+- Acheivable: `<system qualities/desired consequences>`
+- Accepting: `<downside/undesired consequences>`
+- Because: `<additional rationale>`
+
+representing the Y-Statement sentence format:
+
+```In the context of <use case/user story>, facing <concern>, we decided for <option> and neglected <other options>, to achieve <system qualities/desired consequences>, accepting <downside/undesired consequences>, because <additional rationale>.```
+
+## Queryables Endpoint
+
+- Context: advertising terms which can be used in CQL2 filter expressions
+- Concern: where to retrieve the JSON Schema queryables definition from
+- Decision: the JSON Schema queryables should be at a separate endpoint `./queryables`
+- Neglected: the JSON Schema should be embedded within the Product entity
+- Acheivable: a semantically-consistent set of resources that minimizes network requests
+- Accepting: clients will need to retrieve two resources (the product and the product queryables endpoint)
+  in order to search against the product's opportunities
+- Because: the queryables are metadata about the product's metadata, rather than product metadata itself.
+  Therefore, including it in the product metadata is not an appropriate place to add it.
+
+## Opportunity Search and Order Create body format
+
+- Context: JSON body format to POST endpoints for Opportunity Search and Order Create
+- Concern: what attributes should be supported for searching/creating 
+- Decision: a single attribute `filter` supporting a CQL2 expression
+- Neglected: separate `datetime` (interval), `geometry` (intersecting geometry?), and `filter` attributes
+- Acheivable: to provide the simplest interface that supports maximum expressiveness
+- Accepting: API users will need to always use CQL2 expressions even when only using spatial and temporal constraints.
+- Because: `datetime` and `geometry` fields are duplicates of what can be expressed in CQL2 expressions.
+  Most users will not be writing CQL2 statements directly, but instead interacting with the API via a client, which can provide whatever shorthand (e.g., separate properties on a search object) for these "special" fields that it wishes to.

--- a/examples/OpportunityCollection.json
+++ b/examples/OpportunityCollection.json
@@ -14,7 +14,7 @@
                 "start_datetime": "2023-03-01T13:00:00Z",
                 "end_datetime": "2023-03-2T15:30:00Z",
                 "product_id": "EO",
-                "constraints": {
+                "opportunity_properties": {
                     "gsd": [
                         1.0,
                         10.0
@@ -55,7 +55,7 @@
                 "start_datetime": "2023-03-02T13:00:00Z",
                 "end_datetime": "2023-03-03T15:30:00Z",
                 "product_id": "EO",
-                "constraints": {
+                "opportunity_properties": {
                     "gsd": [
                         1.0,
                         10.0

--- a/examples/OpportunityCollectionV2.json
+++ b/examples/OpportunityCollectionV2.json
@@ -3,7 +3,13 @@
     "features": [
         {
             "type": "Feature",
-            "geometry": {"type": "Point", "coordinates": [0, 0]},
+            "geometry": {
+                "type": "Point",
+                "coordinates": [
+                    0,
+                    0
+                ]
+            },
             "id": "abc",
             "properties": {
                 "product_id": "xyz",
@@ -11,7 +17,7 @@
                 "view:offnadir_angle": 20,
                 "view:sun_azimuth": 150,
                 "view:sun_elevation": 30,
-                "weather:cloud_cover": 20,
+                "eo:cloud_cover": 20,
                 "weather:precipitation": 0
             },
             "links": [
@@ -32,29 +38,81 @@
             "method": "POST",
             "href": "https://example.com/products/xyz/order",
             "body": {
-                "geometry": {
-                    "type": "Polygon",
-                    "coordinates": [
-                        [
-                            [0, 0],
-                            [1, 0],
-                            [1, 1],
-                            [0, 1],
-                            [0, 0]
-                        ]
-                      ]
-                },
-                "datetime": "2020-01-01T00:00:00Z/2020-01-02T00:00:00Z",
                 "filter": {
                     "op": "and",
                     "args": [
                         {
-                            "op": "between",
-                            "args": [{ "property": "weather:cloud_cover" }, 20, 30]
+                            "op": "s_intersects",
+                            "args": [
+                                {
+                                    "property": "geometry"
+                                },
+                                {
+                                    "type": "Polygon",
+                                    "coordinates": [
+                                        [
+                                            [
+                                                0,
+                                                0
+                                            ],
+                                            [
+                                                1,
+                                                0
+                                            ],
+                                            [
+                                                1,
+                                                1
+                                            ],
+                                            [
+                                                0,
+                                                1
+                                            ],
+                                            [
+                                                0,
+                                                0
+                                            ]
+                                        ]
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "op": ">=",
+                            "args": [
+                                {
+                                    "property": "datetime"
+                                },
+                                "2020-01-01T00:00:00Z"
+                            ]
+                        },
+                        {
+                            "op": "<=",
+                            "args": [
+                                {
+                                    "property": "datetime"
+                                },
+                                "2020-01-02T00:00:00Z"
+                            ]
                         },
                         {
                             "op": "between",
-                            "args": [{ "property": "view:offnadir_angle" }, 15, 30]
+                            "args": [
+                                {
+                                    "property": "eo:cloud_cover"
+                                },
+                                20,
+                                30
+                            ]
+                        },
+                        {
+                            "op": "between",
+                            "args": [
+                                {
+                                    "property": "view:offnadir_angle"
+                                },
+                                15,
+                                30
+                            ]
                         }
                     ]
                 }

--- a/examples/OpportunityRequestV2.json
+++ b/examples/OpportunityRequestV2.json
@@ -1,28 +1,80 @@
 {
-  "geometry": {
-    "type": "Polygon",
-    "coordinates": [
-      [
-        [0, 0],
-        [1, 0],
-        [1, 1],
-        [0, 1],
-        [0, 0]
-      ]
-    ]
-  },
-  "datetime": "2020-01-01T00:00:00Z/2020-01-02T00:00:00Z",
   "filter": {
     "op": "and",
     "args": [
-      {
-        "op": "between",
-        "args": [{ "property": "weather:cloud_cover" }, 20, 30]
-      },
-      {
-        "op": "between",
-        "args": [{ "property": "view:offnadir_angle" }, 15, 30]
-      }
+        {
+            "op": "s_intersects",
+            "args": [
+                {
+                    "property": "geometry"
+                },
+                {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [
+                                0,
+                                0
+                            ],
+                            [
+                                1,
+                                0
+                            ],
+                            [
+                                1,
+                                1
+                            ],
+                            [
+                                0,
+                                1
+                            ],
+                            [
+                                0,
+                                0
+                            ]
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "op": ">=",
+            "args": [
+                {
+                    "property": "datetime"
+                },
+                "2020-01-01T00:00:00Z"
+            ]
+        },
+        {
+            "op": "<=",
+            "args": [
+                {
+                    "property": "datetime"
+                },
+                "2020-01-02T00:00:00Z"
+            ]
+        },
+        {
+            "op": "between",
+            "args": [
+                {
+                    "property": "eo:cloud_cover"
+                },
+                20,
+                30
+            ]
+        },
+        {
+            "op": "between",
+            "args": [
+                {
+                    "property": "view:offnadir_angle"
+                },
+                15,
+                30
+            ]
+        }
     ]
-  }
+}
 }

--- a/examples/Order.json
+++ b/examples/Order.json
@@ -7,7 +7,7 @@
             0
         ]
     },
-    "constraints": {
+    "opportunity_properties": {
         "gsd": {
             "minimum": 9.0,
             "maximum": 10.0

--- a/examples/ProductCollection.json
+++ b/examples/ProductCollection.json
@@ -5,12 +5,17 @@
             "id": "multispectral",
             "title": "Multispectral",
             "description": "Full color EO image",
-            "keywords": ["EO", "color"],
+            "keywords": [
+                "EO",
+                "color"
+            ],
             "license": "license",
             "providers": {
                 "name": "planet",
                 "description": "planet description",
-                "roles": ["producer"],
+                "roles": [
+                    "producer"
+                ],
                 "url": "planet link"
             },
             "links": {
@@ -18,38 +23,6 @@
                 "rel": "latest-version",
                 "type": "media type",
                 "title": "title"
-            },
-            "constraints": {
-                "gsd": {
-                    "minimum": 0.5,
-                    "maximum": 10.0
-                },
-                "target_elevation": {
-                    "minimum": 30.0,
-                    "maximum": 90.0
-                },
-                "target_azimuth": {
-                    "minimum": -360.0,
-                    "maximum": 360.0
-                },
-                "view:sun_elevation": {
-                    "minimum": 10.0,
-                    "maximum": 90.0
-                },
-                "view:sun_azimuth": {
-                    "minimum": -360.0,
-                    "maximum": 360.0
-                },
-                "view:off_nadir": {
-                    "minimum": 0.0,
-                    "maximum": 30.0
-                },
-                "cloud_coverage_prediction_max": {
-                    "type": "number",
-                    "minimum": 0,
-                    "maximum": 100,
-                    "multipleOf": 0.01
-                }
             },
             "parameters": {
                 "eo:cloud_cover": {
@@ -97,12 +70,17 @@
             "id": "spotlight",
             "title": "Spotlight",
             "description": "SAR Spotlight frame",
-            "keywords": ["SAR", "spotlight"],
+            "keywords": [
+                "SAR",
+                "spotlight"
+            ],
             "license": "license",
             "providers": {
                 "name": "planet",
                 "description": "planet description",
-                "roles": ["producer"],
+                "roles": [
+                    "producer"
+                ],
                 "url": "planet link"
             },
             "links": {
@@ -110,28 +88,6 @@
                 "rel": "latest-version",
                 "type": "media type",
                 "title": "title"
-            },
-            "constraints": {
-                "sar:resolution_range": {
-                    "minimum": 0.5,
-                    "maximum": 5.0
-                },
-                "sar:resolution_azimuth": {
-                    "minimum": 0.5,
-                    "maximum": 5.0
-                },
-                "grazing": {
-                    "minimum": 20.0,
-                    "maximum": 40.0
-                },
-                "target_azimuth": {
-                    "minimum": -360.0,
-                    "maximum": 360.0
-                },
-                "squint": {
-                    "minimum": -5.0,
-                    "maximum": 5.0
-                }
             },
             "parameters": {
                 "sar:polarizarions": [

--- a/examples/ProductQueryables.json
+++ b/examples/ProductQueryables.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "schema.json",
+    "type": "object",
+    "properties": {
+        "gsd": {
+            "minimum": 0.5,
+            "maximum": 10.0
+        },
+        "target_elevation": {
+            "minimum": 30.0,
+            "maximum": 90.0
+        },
+        "target_azimuth": {
+            "minimum": -360.0,
+            "maximum": 360.0
+        },
+        "view:sun_elevation": {
+            "minimum": 10.0,
+            "maximum": 90.0
+        },
+        "view:sun_azimuth": {
+            "minimum": -360.0,
+            "maximum": 360.0
+        },
+        "view:off_nadir": {
+            "minimum": 0.0,
+            "maximum": 30.0
+        },
+        "cloud_coverage_prediction_max": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100,
+            "multipleOf": 0.01
+        }
+    }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -133,12 +133,12 @@ paths:
           $ref: "#/components/responses/Error"
         "5XX":
           $ref: "#/components/responses/Error"
-  "/products/{productId}/constraints":
+  "/products/{productId}/queryables":
     get:
       tags:
         - Products
       summary: |-
-        describe the constraints for a product
+        describe the queryables for the CQL2 filter applied to product opportunities
       description: |-
         ...
       parameters:
@@ -535,7 +535,7 @@ components:
       description: STAPI Product objects are represented in JSON format and are very flexible. 
                   Any JSON object that contains all the required fields is a valid STAPI Product. 
                   A Product object contains a minimal set of required properties to be valid and 
-                  can be extended through the use of constraints and parameters.
+                  can be extended through the use of queryables and parameters.
       required:
         - type
         - id

--- a/opportunity/README.md
+++ b/opportunity/README.md
@@ -6,23 +6,22 @@ The STAPI Opportunity describes a single business unit available for ordering.
 
 ## Opportunity Request
 
-for `POST /products/{productId}/opportunities`
+For `POST /products/{productId}/opportunities`
+
+### Path Parameters
 
 | Field Name | Type                                                                       | Description |
 |------------| -------------------------------------------------------------------------- | ----------- |
-| datetime   | string                                                                     | **REQUIRED.** Time interval with a solidus (forward slash, `/`)  separator, using [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6) datetime, empty string, or `..` values. |
-| productId  | string                                                                     | **REQUIRED.** Product identifier. The ID should be unique and is a reference to the [parameters](https://github.com/Element84/stapi-spec/blob/main/product/README.md#parameters) which can be used in the [parameters](https://github.com/Element84/stapi-spec/blob/main/product/README.md#parameters) field. |
-| geometry   | [GeoJSON Geometry Object](https://tools.ietf.org/html/rfc7946#section-3.1) | **REQUIRED.** Defines the full footprint of the asset represented by this item, formatted according to [RFC 7946, section 3.1](https://tools.ietf.org/html/rfc7946#section-3.1). The footprint should be the default GeoJSON geometry, though additional geometries can be included. Coordinates are specified in Longitude/Latitude or Longitude/Latitude/Elevation based on [WGS 84](http://www.opengis.net/def/crs/OGC/1.3/CRS84). |
+| productId  | string                                                                     | Product identifier. The ID should be unique and is a reference to the specific Product |
+
+### Body Parameters
+
+| Field Name | Type                                                                       | Description |
+|------------| -------------------------------------------------------------------------- | ----------- |
 | filter     | CQL2 Object | A set of additional [parameters](https://github.com/Element84/stapi-spec/blob/main/product/README.md#parameters) in [CQL2 JSON](https://docs.ogc.org/DRAFTS/21-065.html) based on the [parameters](https://github.com/Element84/stapi-spec/blob/main/product/README.md#parameters) exposed in the product. |
 
-#### datetime
-
-The datetime parameter represents a time interval with which the temporal property of the results must intersect. This parameter allows a subset of the allowed values for a [ISO 8601 Time Interval](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals) or a 
-[OAF datetime](http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#_parameter_datetime) parameter.
-This allows for either
-open or closed intervals, with end definitions separated by a solidus (forward slash, `/`) separator. Closed ends are represented by
-[RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) datetimes. Open ends are represented
-by either an empty string or `..`. Only singly-open intervals are allowed.  Examples of valid datetime intervals include `2024-04-18T10:56:00+01:00/2024-04-25T10:56:00+01:00`, `2024-04-18T10:56:00Z/..`, and `/2024-04-25T10:56:00+01:00`
+Note that `datetime` and `geometry` are no longer parameters, as filters on these can be expressed in CQL2. Datetime restrictions can be expressed via comparison operators using RFC 3339 datetime string values. Geometry
+restrictions can be expressed using the `s_intersects` operator.
 
 ## Opportunity Collection
 

--- a/opportunity/examples/umbra/OpportunityRequestUmbra.json
+++ b/opportunity/examples/umbra/OpportunityRequestUmbra.json
@@ -1,15 +1,40 @@
 {
-  "datetime": "2024-04-19T00:00:00Z/2024-04-23T00:00:00Z",
-  "geometry": {
-    "type": "Point",
-    "coordinates": [
-      13.403258555886767,
-      52.473696635108176
-    ]
-  },
   "filter": {
     "op": "and",
     "args": [
+      {
+        "op": "s_intersects",
+        "args": [
+          {
+            "property": "geometry"
+          },
+          {
+            "type": "Point",
+            "coordinates": [
+              13.403258555886767,
+              52.473696635108176
+            ]
+          }
+        ]
+      },
+      {
+        "op": ">=",
+        "args": [
+          {
+            "property": "datetime"
+          },
+          "2024-04-19T00:00:00Z"
+        ]
+      },
+      {
+        "op": "<=",
+        "args": [
+          {
+            "property": "datetime"
+          },
+          "2024-04-23T00:00:00Z"
+        ]
+      },
       {
         "op": ">=",
         "args": [

--- a/order/README.md
+++ b/order/README.md
@@ -8,23 +8,22 @@ Ordering with loosely defined order values will give the provider more freedom t
 
 The following fields can be sent to `POST /products/{productId}/orders`:
 
-| Field Name | Type                             | Description                                                  |
-|------------| -------------------------------- | ------------------------------------------------------------ |
-| datetime   | string                                                                     | **REQUIRED.** Time interval with a solidus (forward slash, `/`)  separator, using [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6) datetime, empty string, or `..` values. |
-| productId  | string                           | **REQUIRED.** Product identifier. The ID should be unique and is a reference to the [parameters](https://github.com/Element84/stapi-spec/blob/main/product/README.md#parameters) which can be used in the [parameters](https://github.com/Element84/stapi-spec/blob/main/product/README.md#parameters) field. |
-| geometry   | GeoJSON Object \| JSON Reference | **REQUIRED.** Provide a Geometry that the tasked data must be within. |
-| filter     | CQL2 JSON                        | A set of additional [parameters](https://github.com/Element84/stapi-spec/blob/main/product/README.md#parameters) in [CQL2 JSON](https://docs.ogc.org/DRAFTS/21-065.html) based on the [parameters](https://github.com/Element84/stapi-spec/blob/main/product/README.md#parameters) exposed in the product. |
+### Path Parameters
 
-##### datetime
+| Field Name | Type                                                                       | Description |
+|------------| -------------------------------------------------------------------------- | ----------- |
+| productId  | string                                                                     | Product identifier. The ID should be unique and is a reference to the specific Product |
 
-The datetime parameter represents a time interval with which the temporal property of the results must intersect. This parameter allows a subset of the allowed values for a [ISO 8601 Time Interval](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals) or a 
-[OAF datetime](http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#_parameter_datetime) parameter.
-This allows for either
-open or closed intervals, with end definitions separated by a solidus (forward slash, `/`) separator. Closed ends are represented by
-[RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) datetimes. Open ends are represented
-by either an empty string or `..`. Only singly-open intervals are allowed.  Examples of valid datetime intervals include `2024-04-18T10:56:00+01:00/2024-04-25T10:56:00+01:00`, `2024-04-18T10:56:00Z/..`, and `/2024-04-25T10:56:00+01:00`
+### Body Parameters
 
-#### geometry
+| Field Name | Type                                                                       | Description |
+|------------| -------------------------------------------------------------------------- | ----------- |
+| filter     | CQL2 Object | A set of additional [parameters](https://github.com/Element84/stapi-spec/blob/main/product/README.md#parameters) in [CQL2 JSON](https://docs.ogc.org/DRAFTS/21-065.html) based on the [parameters](https://github.com/Element84/stapi-spec/blob/main/product/README.md#parameters) exposed in the product. |
+
+Note that `datetime` and `geometry` are no longer parameters, as filters on these can be expressed in CQL2. Datetime restrictions can be expressed via comparison operators using RFC 3339 datetime string values. Geometry
+restrictions can be expressed using the `s_intersects` operator.
+
+**TODO**: Evaluate supporting external resolution of GeoJSON references is tricky, since it requires that the server retrieve something. Re-evaluate whether this should be allowed or the GeoJSON has to be embedded.
 
 Provides a GeoJSON Geometry Object, can be an embedded GeoJSON object or a [JSON Reference](https://json-spec.readthedocs.io/reference.html) that resolves to a GeoJSON. In both cases the GeoJSON must be compliant to [RFC 7946, section 3.1](https://tools.ietf.org/html/rfc7946#section-3.1). Coordinates are specified in Longitude/Latitude or Longitude/Latitude/Elevation based on [WGS 84](http://www.opengis.net/def/crs/OGC/1.3/CRS84).
 

--- a/product/README.md
+++ b/product/README.md
@@ -13,9 +13,9 @@ A STAPI Product is remote sensing data or derived insights with spatio-temporal 
 - Object (movable) detection
 - Change detection
 
-Some Providers may offer only data or analytic Products while some may offer both. The Product specification is flexible enough to offer constraints at the level of the product offering. For example, a ship (object) detection Product may only specify constraints like location, datetime, and min ship length. The specific data products -- SAR, EO, or otherwise can be left as an implementation detail to the analytic Product Provider.
+Some Providers may offer only data or analytic Products while some may offer both. The Product specification is flexible enough to offer queryables at the level of the product offering. For example, a ship (object) detection Product may only specify queryables like location, datetime, and minimum ship length. The specific data products -- SAR, EO, or otherwise can be left as an implementation detail to the analytic Product Provider.
 
-STAPI Product objects are represented in JSON format and are very flexible. Any JSON object that contains all the required fields is a valid STAPI Product. A Product object contains a minimal set of required properties to be valid and can be extended through the use of constraints and parameters.
+STAPI Product objects are represented in JSON format and are very flexible. Any JSON object that contains all the required fields is a valid STAPI Product. A Product object contains a minimal set of required properties to be valid and can be extended through the use of queryables and parameters.
 
 ## Product Collection Spec
 
@@ -74,35 +74,43 @@ This object describes a relationship with another entity. Data providers are adv
 | type       | string | Media Type of the referenced entity. |
 | title      | string | A human readable title to be used in rendered displays of the link. |
 
-The relation type `constraints` is to be used to link to the `GET /products/{productId}/constraints` endpoint.
+The relation type `queryables` is to be used to link to the `GET /products/{productId}/queryables` endpoint.
 
 The relation type `order-parameters` is to be used to link to the `GET /products/{productId}/order-parameters` endpoint.
 
-## Constraints
+## Queryables 
 
-Constraints define the Opportunity and Order properties that can be used in CQL2 JSON filter statements  to reduce the results set.
-For example, a `constraint` might be `weather:cloud_cover` which allows users to filter Opportunities to only results with `weather:cloud_cover` within a certain range. 
+Queryables define the Opportunity and Order properties that can be used in CQL2 JSON filter expressions to
+filter the set of results.
+For example, a `queryables` might be `eo:cloud_cover` which allows users to filter Opportunities to only results with `eo:cloud_cover` within a certain range. 
 
-The constraints must be exposed as a separate endpoint that is provided at 
-`GET /products/{productId}/constraints`.
+The queryables must be exposed as a separate endpoint that is provided at 
+`GET /products/{productId}/queryables`.
 
-The response body for parameters is a JSON Schema definition.
-Empty schemas are not allowed.
-It is recommended to use [JSON Schema draft-07](https://json-schema.org/specification-links.html#draft-7).
-For an introduction to JSON Schema, see
-[Learn JSON Schema](https://json-schema.org/learn/getting-started-step-by-step).
+The response body for parameters is a JSON Schema definition. Empty schemas are not allowed.
+It is required to use [JSON Schema 2020-12](https://json-schema.org/draft/2020-12/schema).
+This definition should follow the same conventions
+defined by the [OGC API - Features - Part 3: Filtering](https://docs.ogc.org/is/19-079r2/19-079r2.html) Requirements Class "Queryables", including:
 
-#### Constraints Best Practices
+- The Content-Type of the response should be `application/schema+json`
+- The property $schema is `https://json-schema.org/draft/2020-12/schema`
+- The property $id is the URI of the resource without query parameters, e.g., `https://stapi.example.com/products/my_product/queryables`
+- The type is `object`
+
+#### Queryables Best Practices
 
 There are many Tasking constraints that cannot be represented by JSON Schema. For these constraints, strongly consider documenting the constraint in the `description` property of the relevant constraint or use the `"links"` attribute to link the user out to documentation that describes additional constraints.
 
+TODO: Is this actually the case?
 TODO: Example
 TODO: Documented link type for client libraries to be able to find and surface to users
 
 ## Order Parameters
 
 Order Parameters define the properties that can be used when creating an Order. These are different
-than Constraints, in that they do not constrain the desired results, but rather 
+than queryables, in that they do not constrain the desired results, but instead are used to specify
+desired properties of the entities that fulfill an order. For example, the desired file format (COG vs. NITF)
+or cloud object storage location (AWS S3 vs. Microsoft Azure) may be an order parameter.
 
 For example, an order parameter might define what file format or what cloud service provider that
 the order will be delivered in.
@@ -112,9 +120,7 @@ The parameters must be exposed as a separate endpoint that is provided at
 
 The response body for order parameters is a JSON Schema definition.
 Empty schemas are not allowed.
-It is recommended to use [JSON Schema draft-07](https://json-schema.org/specification-links.html#draft-7).
-For an introduction to JSON Schema, see
-[Learn JSON Schema](https://json-schema.org/learn/getting-started-step-by-step).
+It is required to use [JSON Schema 2020-12](https://json-schema.org/draft/2020-12/schema).
 
 #### Order Parameters Best Practices
 

--- a/product/examples/ProductCollectionUmbra.json
+++ b/product/examples/ProductCollectionUmbra.json
@@ -26,85 +26,7 @@
         "rel": "documentation",
         "type": "docs",
         "title": "Canopy Documentation"
-      }],
-      "constraints": {
-        "$defs": {
-          "ProductType": {
-            "enum": [
-              "GEC",
-              "SIDD"
-            ],
-            "title": "ProductType",
-            "type": "string"
-          },
-          "SceneSize": {
-            "enum": [
-              "5x5_KM",
-              "10x10_KM"
-            ],
-            "title": "SceneSize",
-            "type": "string"
-          }
-        },
-        "description": "Umbra Spotlight constraints docstring",
-        "properties": {
-          "sceneSize": {
-            "allOf": [
-              {
-                "$ref": "#/parameters/$defs/SceneSize"
-              }
-            ],
-            "default": "5x5_KM",
-            "description": "The scene size of the Spotlight collect. The first "
-          },
-          "grazingAngleDegrees": {
-            "type": "number",
-            "minimum": 40,
-            "maximum": 70,
-            "description": "The minimum angle between the local tangent plane at the target location and the line of sight vector between the satellite and the target. First value is the minimum grazing angle the second is the maximum.",
-            "title": "Grazing Angle Degrees"
-          },
-          "satelliteIds": {
-            "description": "The satellites to consider for this Opportunity.",
-            "items": {
-              "type": "string",
-              "regex": "Umbra-\\d{2}"
-            },
-            "title": "Satelliteids",
-            "type": "array"
-          },
-          "deliveryConfigId": {
-            "anyOf": [
-              {
-                "format": "uuid",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "",
-            "title": "Deliveryconfigid"
-          },
-          "productTypes": {
-            "default": [
-              "GEC"
-            ],
-            "description": "",
-            "items": {
-              "$ref": "#/parameters/$defs/ProductType"
-            },
-            "title": "Producttypes",
-            "type": "array"
-          }
-        },
-        "required": [
-          "satelliteIds"
-        ],
-        "title": "UmbraSpotlightParameters",
-        "type": "object"
-      }
+      }]
     },
     {
       "type": "Product",
@@ -133,34 +55,7 @@
         "rel": "documentation",
         "type": "docs",
         "title": "Canopy Documentation"
-      }],
-      "constraints": {
-        "description": "Umbra Archive Catalog constraints docstring",
-        "properties": {
-          "sar:resolution_range": {
-            "type": "number",
-            "minimum": 0.25,
-            "maximum": 1,
-            "description": "The range resolution of the SAR Image. This is equivalent to the resolution of the ground plane projected GEC Cloud-Optimized Geotiff",
-            "title": "Range Resolution (m)"
-          },
-          "sar:looks_azimuth": {
-            "type": "number",
-            "minimum": 1,
-            "maximum": 10,
-            "description": "The azimuth looks in the SAR Image. This value times the sar:resolution_range gives the azimuth resolution of the complex products.",
-            "title": "Range Resolution (m)"
-          },
-          "platform": {
-            "description": "The satellites to consider for this Opportunity.",
-            "title": "Platform (Satellite)",
-            "type": "string",
-            "regex": "Umbra-\\d{2}"
-          }
-        },
-        "title": "UmbraArchiveCatalogConstraints",
-        "type": "object"
-      }
+      }]
     }
   ]
 }

--- a/product/examples/ProductConstraintsBlackSky_BSKY_STEREO.json
+++ b/product/examples/ProductConstraintsBlackSky_BSKY_STEREO.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "$defs": {
         "Analytics": {

--- a/product/examples/ProductConstraintsOneatlas_4f866cd3-d816-4c98-ace3-e6105623cf13.json
+++ b/product/examples/ProductConstraintsOneatlas_4f866cd3-d816-4c98-ace3-e6105623cf13.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {
         "acquisitionMode": {

--- a/product/examples/ProductConstraintsPlanet_PL-123456:AssuredTasking.json
+++ b/product/examples/ProductConstraintsPlanet_PL-123456:AssuredTasking.json
@@ -1,63 +1,63 @@
 {
-                "$defs": {
-                    "scheduling_type": {
-                        "enum": [
-                            "Assured"
-                        ],
-                        "title": "Scheduling Type",
-                        "type": "string"
-                    },
-                    "satellite_types": {
-                        "enum": [
-                            "SkySat"
-                        ],
-                        "title": "Satellite Types",
-                        "type": "string"
-                    },
-                    "exclusivity_days": {
-                        "enum": [
-                            0,
-                            30
-                        ],
-                        "title": "Exclusivity Days",
-                        "type": "number"
-                    },
-                    "imaging_window_id": {
-                        "title": "Imaging Window ID (added to filters in the opportunities response)",
-                        "type": "string"
-                    }
-                },
-                "description": "Planet Assured constraints docstring",
-                "properties": {
-                    "scheduling_type": {
-                        "allOf": [
-                            {
-                                "$ref": "#/parameters/$defs/scheduling_type"
-                            }
-                        ],
-                        "default": "Assured",
-                        "title": "Scheduling Type"
-                    },
-                    "satellite_types": {
-                        "items": [
-                            {
-                                "$ref": "#/parameters/$defs/satellite_types"
-                            }
-                        ],
-                        "default": [
-                            "SkySat"
-                        ],
-                        "type": "array",
-                        "title": "Satellite Types"
-                    },
-                    "exclusivity_days": {
-                        "allOf": [
-                            {
-                                "$ref": "#/parameters/$defs/exclusivity_days"
-                            }
-                        ],
-                        "default": 0,
-                        "title": "Exclusivity Days"
-                    }
+    "$defs": {
+        "scheduling_type": {
+            "enum": [
+                "Assured"
+            ],
+            "title": "Scheduling Type",
+            "type": "string"
+        },
+        "satellite_types": {
+            "enum": [
+                "SkySat"
+            ],
+            "title": "Satellite Types",
+            "type": "string"
+        },
+        "exclusivity_days": {
+            "enum": [
+                0,
+                30
+            ],
+            "title": "Exclusivity Days",
+            "type": "number"
+        },
+        "imaging_window_id": {
+            "title": "Imaging Window ID (added to filters in the opportunities response)",
+            "type": "string"
+        }
+    },
+    "description": "Planet Assured queryables docstring",
+    "properties": {
+        "scheduling_type": {
+            "allOf": [
+                {
+                    "$ref": "#/parameters/$defs/scheduling_type"
                 }
-            }
+            ],
+            "default": "Assured",
+            "title": "Scheduling Type"
+        },
+        "satellite_types": {
+            "items": [
+                {
+                    "$ref": "#/parameters/$defs/satellite_types"
+                }
+            ],
+            "default": [
+                "SkySat"
+            ],
+            "type": "array",
+            "title": "Satellite Types"
+        },
+        "exclusivity_days": {
+            "allOf": [
+                {
+                    "$ref": "#/parameters/$defs/exclusivity_days"
+                }
+            ],
+            "default": 0,
+            "title": "Exclusivity Days"
+        }
+    }
+}

--- a/product/examples/ProductConstraintsPlanet_PL-123456:FlexibleTasking.json
+++ b/product/examples/ProductConstraintsPlanet_PL-123456:FlexibleTasking.json
@@ -1,4 +1,4 @@
- {
+{
     "$defs": {
         "scheduling_type": {
             "enum": [
@@ -23,7 +23,7 @@
             "type": "number"
         }
     },
-    "description": "Planet Flexible constraints docstring",
+    "description": "Planet Flexible queryables docstring",
     "properties": {
         "scheduling_type": {
             "allOf": [

--- a/product/examples/ProductConstraintsUmbra_umbra_spotlight.json
+++ b/product/examples/ProductConstraintsUmbra_umbra_spotlight.json
@@ -1,78 +1,78 @@
 {
-        "$defs": {
-            "ProductType": {
-                "enum": [
-                    "GEC",
-                    "SIDD"
-                ],
-                "title": "ProductType",
-                "type": "string"
-            },
-            "SceneSize": {
-                "enum": [
-                    "5x5_KM",
-                    "10x10_KM"
-                ],
-                "title": "SceneSize",
-                "type": "string"
-            }
+    "$defs": {
+        "ProductType": {
+            "enum": [
+                "GEC",
+                "SIDD"
+            ],
+            "title": "ProductType",
+            "type": "string"
         },
-        "description": "Umbra Spotlight constraints docstring",
-        "properties": {
-            "sceneSize": {
-                "allOf": [
-                    {
-                        "$ref": "#/parameters/$defs/SceneSize"
-                    }
-                ],
-                "default": "5x5_KM",
-                "description": "The scene size of the Spotlight collect. The first "
-            },
-            "grazingAngleDegrees": {
-                "type": "number",
-                "minimum": 40,
-                "maximum": 70,
-                "description": "The minimum angle between the local tangent plane at the target location and the line of sight vector between the satellite and the target. First value is the minimum grazing angle the second is the maximum.",
-                "title": "Grazing Angle Degrees"
-            },
-            "satelliteIds": {
-                "description": "The satellites to consider for this Opportunity.",
-                "items": {
-                    "type": "string",
-                    "regex": "Umbra-\\d{2}"
-                },
-                "title": "Satelliteids",
-                "type": "array"
-            },
-            "deliveryConfigId": {
-                "anyOf": [
-                    {
-                        "format": "uuid",
-                        "type": "string"
-                    },
-                    {
-                        "type": "null"
-                    }
-                ],
-                "default": null,
-                "description": "",
-                "title": "Deliveryconfigid"
-            },
-            "productTypes": {
-                "default": [
-                    "GEC"
-                ],
-                "description": "",
-                "items": {
-                    "$ref": "#/parameters/$defs/ProductType"
-                },
-                "title": "Producttypes",
-                "type": "array"
-            }
+        "SceneSize": {
+            "enum": [
+                "5x5_KM",
+                "10x10_KM"
+            ],
+            "title": "SceneSize",
+            "type": "string"
+        }
+    },
+    "description": "Umbra Spotlight queryables docstring",
+    "properties": {
+        "sceneSize": {
+            "allOf": [
+                {
+                    "$ref": "#/parameters/$defs/SceneSize"
+                }
+            ],
+            "default": "5x5_KM",
+            "description": "The scene size of the Spotlight collect. The first "
         },
-        "required": [
-            "satelliteIds"
-        ],
-        "title": "UmbraSpotlightParameters",
-        "type": "object"
-    }
+        "grazingAngleDegrees": {
+            "type": "number",
+            "minimum": 40,
+            "maximum": 70,
+            "description": "The minimum angle between the local tangent plane at the target location and the line of sight vector between the satellite and the target. First value is the minimum grazing angle the second is the maximum.",
+            "title": "Grazing Angle Degrees"
+        },
+        "satelliteIds": {
+            "description": "The satellites to consider for this Opportunity.",
+            "items": {
+                "type": "string",
+                "regex": "Umbra-\\d{2}"
+            },
+            "title": "Satelliteids",
+            "type": "array"
+        },
+        "deliveryConfigId": {
+            "anyOf": [
+                {
+                    "format": "uuid",
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null,
+            "description": "",
+            "title": "Deliveryconfigid"
+        },
+        "productTypes": {
+            "default": [
+                "GEC"
+            ],
+            "description": "",
+            "items": {
+                "$ref": "#/parameters/$defs/ProductType"
+            },
+            "title": "Producttypes",
+            "type": "array"
+        }
+    },
+    "required": [
+        "satelliteIds"
+    ],
+    "title": "UmbraSpotlightParameters",
+    "type": "object"
+}

--- a/product/examples/ProductUmbraArchiveQueryables.json
+++ b/product/examples/ProductUmbraArchiveQueryables.json
@@ -1,0 +1,28 @@
+re-write this as JSON Schema
+{
+    "description": "Umbra Archive Catalog queryables docstring",
+    "properties": {
+      "sar:resolution_range": {
+        "type": "number",
+        "minimum": 0.25,
+        "maximum": 1,
+        "description": "The range resolution of the SAR Image. This is equivalent to the resolution of the ground plane projected GEC Cloud-Optimized Geotiff",
+        "title": "Range Resolution (m)"
+      },
+      "sar:looks_azimuth": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 10,
+        "description": "The azimuth looks in the SAR Image. This value times the sar:resolution_range gives the azimuth resolution of the complex products.",
+        "title": "Range Resolution (m)"
+      },
+      "platform": {
+        "description": "The satellites to consider for this Opportunity.",
+        "title": "Platform (Satellite)",
+        "type": "string",
+        "regex": "Umbra-\\d{2}"
+      }
+    },
+    "title": "UmbraArchiveCatalogQueryables",
+    "type": "object"
+  }

--- a/product/examples/ProductUmbraSpotlightQueryables.json
+++ b/product/examples/ProductUmbraSpotlightQueryables.json
@@ -1,0 +1,78 @@
+{
+  "$defs": {
+    "ProductType": {
+      "enum": [
+        "GEC",
+        "SIDD"
+      ],
+      "title": "ProductType",
+      "type": "string"
+    },
+    "SceneSize": {
+      "enum": [
+        "5x5_KM",
+        "10x10_KM"
+      ],
+      "title": "SceneSize",
+      "type": "string"
+    }
+  },
+  "description": "Umbra Spotlight queryables docstring",
+  "properties": {
+    "sceneSize": {
+      "allOf": [
+        {
+          "$ref": "#/parameters/$defs/SceneSize"
+        }
+      ],
+      "default": "5x5_KM",
+      "description": "The scene size of the Spotlight collect. The first "
+    },
+    "grazingAngleDegrees": {
+      "type": "number",
+      "minimum": 40,
+      "maximum": 70,
+      "description": "The minimum angle between the local tangent plane at the target location and the line of sight vector between the satellite and the target. First value is the minimum grazing angle the second is the maximum.",
+      "title": "Grazing Angle Degrees"
+    },
+    "satelliteIds": {
+      "description": "The satellites to consider for this Opportunity.",
+      "items": {
+        "type": "string",
+        "regex": "Umbra-\\d{2}"
+      },
+      "title": "Satelliteids",
+      "type": "array"
+    },
+    "deliveryConfigId": {
+      "anyOf": [
+        {
+          "format": "uuid",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "",
+      "title": "Deliveryconfigid"
+    },
+    "productTypes": {
+      "default": [
+        "GEC"
+      ],
+      "description": "",
+      "items": {
+        "$ref": "#/parameters/$defs/ProductType"
+      },
+      "title": "Producttypes",
+      "type": "array"
+    }
+  },
+  "required": [
+    "satelliteIds"
+  ],
+  "title": "UmbraSpotlightParameters",
+  "type": "object"
+}


### PR DESCRIPTION
1. The definition of "constraints" are the same as "queryables" from OGC Features API Part 3, so it would be good to align the terminology. There is likely an additional concept like "the JSON schema that that Item Properties that fulfill Orders will have", but this need to to be defined better. Previously, we have conflated these two concepts, resulting in a single concept that didn't work perfectly for either.
2. The Opportunities Search body and Order Create body both have fields `datetime` and `geometry`. The values that are allowed in either of these can also be expressed in a `filter` CQL2 expression where Basic-CQL2 and Basic Spatial Functions are supported, so there's no need to have these as separate fields with, in the case of `datetime`, a proprietary format for an interval, and in the case of `geometry`, a different name than STAC API (which uses `intersects`) and undefined spatial semantics (intersects? within?).