### PR TITLE
Add fields stapi_type, stapi_version to entity definitions

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -77,7 +77,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/conformanceClasses"
-      
+
         "4XX":
           $ref: "#/components/responses/Error"
         "5XX":
@@ -196,7 +196,7 @@ paths:
                   allOf:
                    - $ref: "#/components/schemas/order_request"
                 - title: Order Request based on Opportunities
-                  type: object 
+                  type: object
                   description: |-
                     Any body that was provided by the links in the individual opportunities.
       responses:
@@ -531,9 +531,9 @@ components:
             format: url
     product:
       type: object
-      description: STAPI Product objects are represented in JSON format and are very flexible. 
-                  Any JSON object that contains all the required fields is a valid STAPI Product. 
-                  A Product object contains a minimal set of required properties to be valid and 
+      description: STAPI Product objects are represented in JSON format and are very flexible.
+                  Any JSON object that contains all the required fields is a valid STAPI Product.
+                  A Product object contains a minimal set of required properties to be valid and
                   can be extended through the use of constraints and parameters.
       required:
         - type

--- a/opportunity/README.md
+++ b/opportunity/README.md
@@ -82,6 +82,8 @@ This object describes a STAPI Opportunity. The input fields will be contained
 | Field Name | Type | Description |
 | ---------- | ---- | ----------- |
 | type | string | **REQUIRED.** Type of the GeoJSON Object. **Must** be `Feature`. |
+| stapi_type | string | **REQUIRED.** Type of the STAPI Object. **Must** be set to `Opportunity`. |
+| stapi_version | string | **REQUIRED.** The STAPI version the Opportunity implements. |
 | id | string | Provider identifier. This is not required, unless the provider tracks user requests and state for opportunities (as when supporting async searches). |
 | geometry | [GeoJSON Geometry Object](https://tools.ietf.org/html/rfc7946#section-3.1) \| [null](https://tools.ietf.org/html/rfc7946#section-3.2) | **REQUIRED.** Defines the full footprint of the asset represented by this item, formatted according to [RFC 7946, section 3.1](https://tools.ietf.org/html/rfc7946#section-3.1). The footprint should be the default GeoJSON geometry, though additional geometries can be included. Coordinates are specified in Longitude/Latitude or Longitude/Latitude/Elevation based on [WGS 84](http://www.opengis.net/def/crs/OGC/1.3/CRS84). |
 | bbox | [number] | **REQUIRED if `geometry` is not `null`.** Bounding Box of the asset represented by this Item, formatted according to [RFC 7946, section 5](https://tools.ietf.org/html/rfc7946#section-5). |

--- a/order/README.md
+++ b/order/README.md
@@ -83,12 +83,15 @@ See [Order Object](#order-object).
 
 | Field Name | Type | Description |
 | ---------- | ---- | ----------- |
-| id | string | Unique provider generated order ID |
+| type | string | **REQUIRED.** Type of the GeoJSON Object. **Must** be set to `Feature`. |
+| stapi_type | string | **REQUIRED.** Type of the STAPI Object. **Must** be set to `Order`. |
+| stapi_version | string | **REQUIRED.** The STAPI version the Order implements. |
+| id | string | Unique provider generated order ID. |
 | user | string | User or organization ID ? |
-| created | datetime | When the order was created |
+| created | datetime | When the order was created. |
 | product_id | string | **REQUIRED.** Product identifier. This should be a reference to the [Product](https://github.com/Element84/stapi-spec/blob/main/product/README.md) being ordered. |
-| request | [Opportunity Request Object](./opportunity/README.md#opportunity-request-object) | Search parameters for Order |
-| status | [Order Status Object](#order-status) | Current Order Status object |
+| request | [Opportunity Request Object](./opportunity/README.md#opportunity-request-object) | Search parameters for Order. |
+| status | [Order Status Object](#order-status) | Current Order Status object. |
 | links | \[[Link Object](https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md#link-object)\] |  |
 
 If the `GET /orders/{orderId}/statuses` endpoint is implemented, there must be

--- a/product/README.md
+++ b/product/README.md
@@ -25,10 +25,12 @@ STAPI Product objects are represented in JSON format and are very flexible. Any 
 | links | [[Link Object](#link-object)] | **REQUIRED** Links for e.g. pagination. |
 
 
-## Product Object 
+## Product Object
 | Element         | Type                                             | Description                                                  |
 | --------------- | ------------------------------------------------ | ------------------------------------------------------------ |
-| type            | string                                           | **REQUIRED.** Must be set to `Product` to be a valid Product. |
+| type            | string                                           | **REQUIRED.** Must be set to `Collection` to be a valid Product. |
+| stapi_type   | string | **REQUIRED.** Type of the STAPI Object. MUST be set to `Product`.  |
+| stapi_version   | string | **REQUIRED.** The STAPI version the Product implements. |
 | id              | string                                           | **REQUIRED.** Identifier for the Product that is unique across the provider. |
 | conformsTo      | \[string\]                                       | Conformance classes that apply to the product specifically. |
 | title           | string                                           | A short descriptive one-line title for the Product.       |
@@ -38,7 +40,7 @@ STAPI Product objects are represented in JSON format and are very flexible. Any 
 | providers       | \[[Provider Object](#provider-object)]           | A list of providers, which may include all organizations capturing or processing the data or the hosting provider. Providers should be listed in chronological order with the most recent provider being the last element of the list. |                |
 | links           | \[[Link Object](#link-object)]                   | **REQUIRED.** A list of references to other documents.       |
 
-Additional properties are allowed to be placed in the top-level object, comparable to how STAC Collections work. 
+Additional properties are allowed to be placed in the top-level object, comparable to how STAC Collections work.
 STAC Collection fields can be reused, including fields defined in STAC Collection extensions.
 
 ### Provider Object
@@ -81,9 +83,9 @@ The relation type `order-parameters` is to be used to link to the `GET /products
 ## Constraints
 
 Constraints define the Opportunity and Order properties that can be used in CQL2 JSON filter statements  to reduce the results set.
-For example, a `constraint` might be `weather:cloud_cover` which allows users to filter Opportunities to only results with `weather:cloud_cover` within a certain range. 
+For example, a `constraint` might be `weather:cloud_cover` which allows users to filter Opportunities to only results with `weather:cloud_cover` within a certain range.
 
-The constraints must be exposed as a separate endpoint that is provided at 
+The constraints must be exposed as a separate endpoint that is provided at
 `GET /products/{productId}/constraints`.
 
 The response body for parameters is a JSON Schema definition.
@@ -102,12 +104,12 @@ TODO: Documented link type for client libraries to be able to find and surface t
 ## Order Parameters
 
 Order Parameters define the properties that can be used when creating an Order. These are different
-than Constraints, in that they do not constrain the desired results, but rather 
+than Constraints, in that they do not constrain the desired results, but rather
 
 For example, an order parameter might define what file format or what cloud service provider that
 the order will be delivered in.
 
-The parameters must be exposed as a separate endpoint that is provided at 
+The parameters must be exposed as a separate endpoint that is provided at
 `GET /products/{productId}/order-parameters`.
 
 The response body for order parameters is a JSON Schema definition.


### PR DESCRIPTION
The API has multiple object types, some of which extend GeoJSON Feature. It is expected that some API endpoints, e.g., Opportunity Search, may return a mix of item types, like returning both Opportunities that result in Orders being created or existing STAC Items that have already been captured. While heuristics can be used, this is not ideal -- it's easier just to explicitly state what the type of an object is.

The fields stapi_type, stapi_version, and conformsTo have been added to all entity definitions. The examples have not been updated, but will be if there's consensus on this change.

An alternate approach is encapsulate both into `conformsTo` -- so that there would be an entry like `https://stapi.example.com/v1.2.3/opportunity` to indicate that an entity was conformant with STAPI v1.2.3 and that it was an opportunity type.

In other related APIs such as STAC API and OAFeat, `conformsTo` has been used on the Landing Page / Root to define conformance of the API as a whole, rather than on the "Landing Page" entity definition. Perhaps a separate field like `stapi_conformance` should be used instead? 