### PR TITLE
modify order statuses endpoint definition

### DIFF
--- a/extensions/order-status/README.md
+++ b/extensions/order-status/README.md
@@ -8,16 +8,18 @@ The `GET /orders/{orderId}` endpoint must add a link to this endpoint using the 
 
 Endpoint: `GET /orders/{orderId}/statuses`
 
+TODO: Pagination
+
 ## Order Status Request
 
-Get operation only. 
+GET operation only.
 
 ## Order Status Response
 
 Response has two fields:
-| Field Name | Type | Description |
-| ---------- | ---- | ----------- |
-| current | OrderStatus | The current/official status object |
-| history | [OrderStatus] | History of statuses |
+| Field Name | Type            | Description                                            |
+| ---------- | --------------- | ------------------------------------------------------ |
+| statuses   | \[OrderStatus\]   | **REQUIRED.** History of statuses                      |
+| links      | \[Link\] | **REQUIRED.** A list of references to other endpoints. |
 
-The [Order Status](../order/README.md#order-status) object is described in the order README.
+The [Order Status](../../order/README.md#order-status) object is described in the Order README.

--- a/extensions/order-status/README.md
+++ b/extensions/order-status/README.md
@@ -8,7 +8,7 @@ The `GET /orders/{orderId}` endpoint must add a link to this endpoint using the 
 
 Endpoint: `GET /orders/{orderId}/statuses`
 
-TODO: Pagination
+Pagination will follow the convention outlined in [here](../../README.md#pagination).
 
 ## Order Status Request
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -431,18 +431,17 @@ components:
     order_statuses:
       type: object
       required:
-        - conformsTo
+        - statuses
+        - links
       properties:
-        current:
-          description: >-
-            The current status object
-          $ref: "#/components/schemas/order_status"
-        history:
+        statuses:
           description: >-
             History of statuses
           type: array
           items:
             $ref: "#/components/schemas/order_status"
+      links:
+        $ref: "#/components/schemas/links"
     order_request:
       type: object
       required:


### PR DESCRIPTION
This PR changes the definition of the order statuses endpoint entity. The changes are:

- The OrderStatuses entity `current` field has been removed, as the current status is already in the Order entity.
- The OrderStatuses entity `history` field has been renamed to `statuses` to align with a more typical naming scheme.
- The OrderStatuses entity has an added field `links`. This will likely be used for pagination in the future.