### PR TITLE
rename status user_cancelled to user_canceled to have consistent spelling with canceled status

### DIFF
--- a/order/README.md
+++ b/order/README.md
@@ -98,6 +98,7 @@ Links is intended to be the same data structure as links collection in STAC. Lin
 Providers must support these statuses.
 
 State machine intent (currently no mandate to enforce)
+
 * Received -> accepted or rejected.
 * Accepted -> completed or canceled.
 
@@ -115,7 +116,7 @@ Providers may support these statuses.
 Providers may support additional statuses through extensions. For example:
 
 * tasked (indicates tasking commands have been issued to the satellite/constellation)
-* user_cancelled (indicates that the user cancelled the request)
+* user_canceled (indicates that the user canceled the request)
 
 ### Enumerated reason codes
 


### PR DESCRIPTION
* Both are correct English spellings. `canceled` is more American, `cancelled` is more British. 
* Maxar uses `canceled`
* Planet and EICD use `cancelled`

This just makes the user_ one consistent with the existing standard status.