### PR TITLE
docs: Update README to correct order status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Fields that can be included in the response body for `GET /`.
 | `POST /products/{productId}/opportunities`   | `opportunities`    |
 | `GET /orders`                                | `orders`           |
 | `GET /orders/{orderId}`                      | `order`            |
-| `GET /orders/{orderId}/status`               | `monitor`          |
+| `GET /orders/{orderId}/statuses`             | `monitor`          |
 
 `create-order`: A link with this relation type should only be provided in the
 landing page if a user can directly go from the products to the order endpoint


### PR DESCRIPTION
This PR updates the main README to correct the order status endpoint from `status` to `statuses`.