### PR TITLE
docs: update cloud_cover queryable to match eo structure

### DIFF
--- a/examples/OpportunityCollectionV2.json
+++ b/examples/OpportunityCollectionV2.json
@@ -11,8 +11,7 @@
                 "view:offnadir_angle": 20,
                 "view:sun_azimuth": 150,
                 "view:sun_elevation": 30,
-                "weather:cloud_cover": 20,
-                "weather:precipitation": 0
+                "eo:cloud_cover": 20
             },
             "links": [
                 {
@@ -50,7 +49,7 @@
                     "args": [
                         {
                             "op": "between",
-                            "args": [{ "property": "weather:cloud_cover" }, 20, 30]
+                            "args": [{ "property": "eo:cloud_cover" }, 20, 30]
                         },
                         {
                             "op": "between",

--- a/examples/OpportunityRequestV2.json
+++ b/examples/OpportunityRequestV2.json
@@ -17,7 +17,7 @@
     "args": [
       {
         "op": "between",
-        "args": [{ "property": "weather:cloud_cover" }, 20, 30]
+        "args": [{ "property": "eo:cloud_cover" }, 20, 30]
       },
       {
         "op": "between",

--- a/product/README.md
+++ b/product/README.md
@@ -83,7 +83,7 @@ The relation type `order-parameters` is to be used to link to the `GET /products
 ## Constraints
 
 Constraints define the Opportunity and Order properties that can be used in CQL2 JSON filter statements  to reduce the results set.
-For example, a `constraint` might be `weather:cloud_cover` which allows users to filter Opportunities to only results with `weather:cloud_cover` within a certain range.
+For example, a `constraint` might be `eo:cloud_cover` which allows users to filter Opportunities to only results with `eo:cloud_cover` within a certain range.
 
 The constraints must be exposed as a separate endpoint that is provided at
 `GET /products/{productId}/constraints`.


### PR DESCRIPTION
Updating the `weather:cloud_cover` queryable examples to match the expected STAC prefix: `eo`.

Addresses this PR:
- https://github.com/stapi-spec/stapi-spec/issues/263

But there may be other example parameters that could also be reviewed.