### PR TITLE
Rename orders field of OrderCollection to features

### DIFF
--- a/order/README.md
+++ b/order/README.md
@@ -70,7 +70,7 @@ Location: https://example.com/orders/123
 
 | Field Name | Type                      | Description |
 | ---------- | ------------------------- | ----------- |
-| orders     | \[[Order Object](#order-object)\]          | **REQUIRED.** A list of orders. |
+| features   | \[[Order Object](#order-object)\]          | **REQUIRED.** A list of orders. |
 | links      | Map\<object, Link Object> | **REQUIRED.** Links for e.g. pagination. |
 
 ## GET /orders/\{id\}


### PR DESCRIPTION
This aligns the spec with the model implementation in https://github.com/stapi-spec/pystapi/blob/f9f1816f858d5a1595efdd56012e0ed89354c66f/stapi-pydantic/src/stapi_pydantic/order.py#L107