### PR TITLE
Align spelling of cancelled to have two Ls

### DIFF
--- a/opportunity/README.md
+++ b/opportunity/README.md
@@ -230,12 +230,12 @@ Links will be very provider specific.
 - received (indicates search received by provider and it passed format validation.)
 - in_progress (indicates search is running)
 - failed (indicates search will not be fulfilled for some error reason)
-- canceled (indicates search was canceled for any reason)
+- cancelled (indicates search was cancelled for any reason)
 - completed (indicates search has completed successfully and the results can be retrieved)
 
 Providers must support these statuses.
 
 State machine intent (currently no mandate to enforce)
 
-- received -> in_progress or canceled.
-- in_progress -> completed, failed, or canceled.
+- received -> in_progress or cancelled.
+- in_progress -> completed, failed, or cancelled.

--- a/order/README.md
+++ b/order/README.md
@@ -118,14 +118,14 @@ Links will be very provider specific.
 * accepted (indicates order has been accepted)
 * rejected (indicates order will not be fulfilled)
 * completed (indicates provider was able to successfully collect imagery)
-* canceled (indicates provider was unable to collect imagery)
+* cancelled (indicates provider was unable to collect imagery)
 
 Providers must support these statuses.
 
 State machine intent (currently no mandate to enforce)
 
 * Received -> accepted or rejected.
-* Accepted -> completed or canceled.
+* Accepted -> completed or cancelled.
 
 #### Optional status codes
 

--- a/order/examples/OrderStatus/Cancelled.json
+++ b/order/examples/OrderStatus/Cancelled.json
@@ -1,6 +1,6 @@
 {
     "timestamp": "2007-03-01T13:00:00Z",
-    "status_code": "canceled",
+    "status_code": "cancelled",
     "reason_code": "cloud_cover",
     "reason_text": "Cloud coverage of 79% exceeded the order limit of 50%",
     "links": [

--- a/order/examples/OrderStatus/CustomerCancelled.json
+++ b/order/examples/OrderStatus/CustomerCancelled.json
@@ -1,8 +1,8 @@
 {
     "timestamp": "2007-03-01T13:00:00Z",
-    "status_code": "canceled",
-    "reason_code": "customer_canceled",
-    "reason_text": "Customer cancelation via API",
+    "status_code": "cancelled",
+    "reason_code": "customer_cancelled",
+    "reason_text": "Customer cancellation via API",
     "links": [
         {
             "rel": "audit_log",


### PR DESCRIPTION
Spin off of #242. Consensus was that two Ls was more appropriate. This PR aligns the spelling of cancelled to have two Ls.